### PR TITLE
Add env var to allow symlinking source installs

### DIFF
--- a/src/events/Handler.php
+++ b/src/events/Handler.php
@@ -2,6 +2,7 @@
 
 namespace TotaraInstaller\events;
 
+use Composer\Composer;
 use Composer\DependencyResolver\Operation\InstallOperation;
 use Composer\DependencyResolver\Operation\UpdateOperation;
 use Composer\Installer\InstallationManager;
@@ -44,7 +45,8 @@ final class Handler {
 
         $io->write("[TotaraInstaller][{$package->getName()}] Package installation");
 
-        static::installClient($package, $locker, $io, $manager);
+        $force_symlink = static::shouldForceSymlink($event->getComposer());
+        static::installClient($package, $locker, $io, $manager, $force_symlink);
 
         $locker->save();
     }
@@ -78,7 +80,8 @@ final class Handler {
         static::uninstallClient($initial_package, $locker, $io);
 
         // Install Second
-        static::installClient($target_package, $locker, $io, $manager);
+        $force_symlink = static::shouldForceSymlink($event->getComposer());
+        static::installClient($target_package, $locker, $io, $manager, $force_symlink);
 
         $locker->save();
     }
@@ -163,15 +166,43 @@ final class Handler {
     }
 
     /**
+     * Determine whether .client directories should be force-symlinked.
+     *
+     * Returns true only when BOTH of the following conditions are met:
+     *   1. Composer is running with --prefer-source (i.e. preferred-install === 'source')
+     *   2. The developer has opted in via the TOTARA_DEV_SYMLINK environment variable.
+     *
+     * Developers can enable this per-session, per-command, or persistently:
+     *   - One-off:    TOTARA_DEV_SYMLINK=1 composer install --prefer-source
+     *   - Persistent: add `export TOTARA_DEV_SYMLINK=1` to ~/.bashrc or ~/.zshrc
+     *
+     * @param Composer $composer
+     * @return bool
+     */
+    protected static function shouldForceSymlink(Composer $composer): bool {
+        // --prefer-source causes Composer to set preferred-install to the string 'source'.
+        // A per-package array value means no global --prefer-source flag was passed.
+        $preferred_install = $composer->getConfig()->get('preferred-install');
+        if ($preferred_install !== 'source') {
+            return false;
+        }
+
+        // Developer opt-in via environment variable.
+        $env = getenv('TOTARA_DEV_SYMLINK');
+        return $env !== false && $env !== '' && $env !== '0';
+    }
+
+    /**
      * Install package to client directory
      *
      * @param PackageInterface $package
      * @param ClientLocker $locker
      * @param IOInterface $io
      * @param InstallationManager $manager
+     * @param bool $force_symlink When true, force a symlink even if the package directory is not itself a symlink.
      * @return void
      */
-    protected static function installClient(PackageInterface $package, ClientLocker $locker, IOInterface $io, InstallationManager $manager): void {
+    protected static function installClient(PackageInterface $package, ClientLocker $locker, IOInterface $io, InstallationManager $manager, bool $force_symlink = false): void {
         // Figure out if this package has a client component at all (install, we treat it fresh)
         [$component_name, $source_path] = self::discover_client_path($manager, $package);
 
@@ -189,9 +220,9 @@ final class Handler {
         }
 
         $file_system = new Filesystem();
-        $is_symlink_install = Platform::isWindows()
+        $is_symlink_install = $force_symlink || (Platform::isWindows()
             ? $file_system->isJunction($manager->getInstallPath($package))
-            : $file_system->isSymlinkedDirectory($manager->getInstallPath($package));
+            : $file_system->isSymlinkedDirectory($manager->getInstallPath($package)));
         if ($is_symlink_install) {
             $cwd = Platform::getCwd();
             $source_absolute = $cwd . DIRECTORY_SEPARATOR . $source_path;

--- a/src/events/Handler.php
+++ b/src/events/Handler.php
@@ -2,7 +2,6 @@
 
 namespace TotaraInstaller\events;
 
-use Composer\Composer;
 use Composer\DependencyResolver\Operation\InstallOperation;
 use Composer\DependencyResolver\Operation\UpdateOperation;
 use Composer\Installer\InstallationManager;
@@ -45,7 +44,7 @@ final class Handler {
 
         $io->write("[TotaraInstaller][{$package->getName()}] Package installation");
 
-        $force_symlink = static::shouldForceSymlink($event->getComposer());
+        $force_symlink = static::shouldForceSymlink($package);
         static::installClient($package, $locker, $io, $manager, $force_symlink);
 
         $locker->save();
@@ -80,7 +79,7 @@ final class Handler {
         static::uninstallClient($initial_package, $locker, $io);
 
         // Install Second
-        $force_symlink = static::shouldForceSymlink($event->getComposer());
+        $force_symlink = static::shouldForceSymlink($target_package);
         static::installClient($target_package, $locker, $io, $manager, $force_symlink);
 
         $locker->save();
@@ -169,21 +168,18 @@ final class Handler {
      * Determine whether .client directories should be force-symlinked.
      *
      * Returns true only when BOTH of the following conditions are met:
-     *   1. Composer is running with --prefer-source (i.e. preferred-install === 'source')
+     *   1. The package was installed from source (i.e. Composer was run with --prefer-source).
      *   2. The developer has opted in via the TOTARA_DEV_SYMLINK environment variable.
      *
      * Developers can enable this per-session, per-command, or persistently:
      *   - One-off:    TOTARA_DEV_SYMLINK=1 composer install --prefer-source
      *   - Persistent: add `export TOTARA_DEV_SYMLINK=1` to ~/.bashrc or ~/.zshrc
      *
-     * @param Composer $composer
+     * @param PackageInterface $package
      * @return bool
      */
-    protected static function shouldForceSymlink(Composer $composer): bool {
-        // --prefer-source causes Composer to set preferred-install to the string 'source'.
-        // A per-package array value means no global --prefer-source flag was passed.
-        $preferred_install = $composer->getConfig()->get('preferred-install');
-        if ($preferred_install !== 'source') {
+    protected static function shouldForceSymlink(PackageInterface $package): bool {
+        if ($package->getInstallationSource() !== 'source') {
             return false;
         }
 

--- a/tests/HandlerTest.php
+++ b/tests/HandlerTest.php
@@ -1,0 +1,90 @@
+<?php
+
+use Composer\Composer;
+use Composer\Config;
+use PHPUnit\Framework\TestCase;
+use TotaraInstaller\events\Handler;
+
+final class HandlerTest extends TestCase {
+
+    private $original_env;
+
+    protected function setUp(): void {
+        // Snapshot the current env value and start each test with the var absent,
+        // so tests are fully isolated regardless of the developer's shell environment.
+        $this->original_env = getenv('TOTARA_DEV_SYMLINK');
+        putenv('TOTARA_DEV_SYMLINK');
+    }
+
+    protected function tearDown(): void {
+        // Restore whatever the developer had set before the test ran.
+        if ($this->original_env === false) {
+            putenv('TOTARA_DEV_SYMLINK');
+        } else {
+            putenv('TOTARA_DEV_SYMLINK=' . $this->original_env);
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Helpers
+    // -------------------------------------------------------------------------
+
+    /**
+     * Build a minimal Composer mock whose Config returns the given preferred-install value.
+     */
+    private function make_composer($preferred_install): Composer {
+        $config = $this->createMock(Config::class);
+        $config->method('get')
+            ->with('preferred-install')
+            ->willReturn($preferred_install);
+
+        $composer = $this->createMock(Composer::class);
+        $composer->method('getConfig')->willReturn($config);
+
+        return $composer;
+    }
+
+    /**
+     * Invoke the protected static Handler::shouldForceSymlink() via reflection.
+     */
+    private function should_force_symlink(Composer $composer): bool {
+        $method = new ReflectionMethod(Handler::class, 'shouldForceSymlink');
+        return $method->invoke(null, $composer);
+    }
+
+    public function testReturnsFalseWhenPreferredInstallIsNotSource(): void {
+        $this->assertFalse($this->should_force_symlink($this->make_composer('dist')));
+        $this->assertFalse($this->should_force_symlink($this->make_composer('auto')));
+
+        // A per-package preferred-install map means --prefer-source was not passed
+        // as a global CLI flag, so we should not force symlinks.
+        $per_package = ['vendor/some-package' => 'source', 'vendor/other' => 'dist'];
+        $this->assertFalse($this->should_force_symlink($this->make_composer($per_package)));
+    }
+
+    public function testReturnsFalseWhenEnvVarIsInvalid(): void {
+        $composer = $this->make_composer('source');
+        // TOTARA_DEV_SYMLINK was unset in setUp() - it currently has no value
+        $this->assertFalse($this->should_force_symlink($composer));
+
+        putenv('TOTARA_DEV_SYMLINK=');
+        $this->assertFalse($this->should_force_symlink($composer));
+
+        putenv('TOTARA_DEV_SYMLINK=0');
+        $this->assertFalse($this->should_force_symlink($composer));
+    }
+
+    public function testReturnsTrueWhenPreferSourceAndEnvVarIsSet(): void {
+        $composer = $this->make_composer('source');
+
+        putenv('TOTARA_DEV_SYMLINK=1');
+        $this->assertTrue($this->should_force_symlink($composer));
+
+        putenv('TOTARA_DEV_SYMLINK=true');
+        $this->assertTrue($this->should_force_symlink($composer));
+
+        putenv('TOTARA_DEV_SYMLINK=yes');
+        $this->assertTrue($this->should_force_symlink($composer));
+    }
+
+}

--- a/tests/HandlerTest.php
+++ b/tests/HandlerTest.php
@@ -1,7 +1,6 @@
 <?php
 
-use Composer\Composer;
-use Composer\Config;
+use Composer\Package\PackageInterface;
 use PHPUnit\Framework\TestCase;
 use TotaraInstaller\events\Handler;
 
@@ -30,61 +29,62 @@ final class HandlerTest extends TestCase {
     // -------------------------------------------------------------------------
 
     /**
-     * Build a minimal Composer mock whose Config returns the given preferred-install value.
+     * Build a package mock whose getInstallationSource() returns the given value.
      */
-    private function make_composer($preferred_install): Composer {
-        $config = $this->createMock(Config::class);
-        $config->method('get')
-            ->with('preferred-install')
-            ->willReturn($preferred_install);
-
-        $composer = $this->createMock(Composer::class);
-        $composer->method('getConfig')->willReturn($config);
-
-        return $composer;
+    private function make_package(?string $installation_source): PackageInterface {
+        $package = $this->createMock(PackageInterface::class);
+        $package->method('getInstallationSource')->willReturn($installation_source);
+        return $package;
     }
 
     /**
      * Invoke the protected static Handler::shouldForceSymlink() via reflection.
      */
-    private function should_force_symlink(Composer $composer): bool {
+    private function should_force_symlink(PackageInterface $package): bool {
         $method = new ReflectionMethod(Handler::class, 'shouldForceSymlink');
-        return $method->invoke(null, $composer);
+        return $method->invoke(null, $package);
     }
+
+    // -------------------------------------------------------------------------
+    // Package was not installed from source — symlink must never be forced
+    // -------------------------------------------------------------------------
 
     public function testReturnsFalseWhenPreferredInstallIsNotSource(): void {
-        $this->assertFalse($this->should_force_symlink($this->make_composer('dist')));
-        $this->assertFalse($this->should_force_symlink($this->make_composer('auto')));
-
-        // A per-package preferred-install map means --prefer-source was not passed
-        // as a global CLI flag, so we should not force symlinks.
-        $per_package = ['vendor/some-package' => 'source', 'vendor/other' => 'dist'];
-        $this->assertFalse($this->should_force_symlink($this->make_composer($per_package)));
+        $this->assertFalse($this->should_force_symlink($this->make_package('dist')));
+        $this->assertFalse($this->should_force_symlink($this->make_package(null)));
     }
+
+    // -------------------------------------------------------------------------
+    // Package was installed from source but TOTARA_DEV_SYMLINK is absent/disabled
+    // -------------------------------------------------------------------------
 
     public function testReturnsFalseWhenEnvVarIsInvalid(): void {
-        $composer = $this->make_composer('source');
+        $package = $this->make_package('source');
         // TOTARA_DEV_SYMLINK was unset in setUp() - it currently has no value
-        $this->assertFalse($this->should_force_symlink($composer));
+        $this->assertFalse($this->should_force_symlink($package));
 
         putenv('TOTARA_DEV_SYMLINK=');
-        $this->assertFalse($this->should_force_symlink($composer));
+        $this->assertFalse($this->should_force_symlink($package));
 
         putenv('TOTARA_DEV_SYMLINK=0');
-        $this->assertFalse($this->should_force_symlink($composer));
+        $this->assertFalse($this->should_force_symlink($package));
     }
 
+    // -------------------------------------------------------------------------
+    // Both conditions met — symlink must be forced
+    // -------------------------------------------------------------------------
+
     public function testReturnsTrueWhenPreferSourceAndEnvVarIsSet(): void {
-        $composer = $this->make_composer('source');
+        $package = $this->make_package('source');
 
         putenv('TOTARA_DEV_SYMLINK=1');
-        $this->assertTrue($this->should_force_symlink($composer));
+        $this->assertTrue($this->should_force_symlink($package));
 
         putenv('TOTARA_DEV_SYMLINK=true');
-        $this->assertTrue($this->should_force_symlink($composer));
+        $this->assertTrue($this->should_force_symlink($package));
 
         putenv('TOTARA_DEV_SYMLINK=yes');
-        $this->assertTrue($this->should_force_symlink($composer));
+        $this->assertTrue($this->should_force_symlink($package));
     }
 
 }


### PR DESCRIPTION
Adds support for symlinking the TUI `.client` directory when using `--prefer-source`. Requires a developer to either set `TOTARA_DEV_SYMLINK=1` in their global env file (.zshrc/.bashrc) or run Composer prefixed by `TOTARA_DEV_SYMLINK=1 composer install --prefer-source`.

Using `--prefer-source` means as developers we can pull down the repository for every plugin, allowing us to develop those plugins without first manually cloning each plugin repo - especially annoying when we start getting into the 100s of plugins. To further aid development, rather than moving the .client directory out on install (which to the git repo shows as us deleting those files) we can symlink it out - now any changes made in that TUI component will be instantly reflected back into the repo for committing.